### PR TITLE
Updated glossary, added fields, fixed names

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -4,12 +4,12 @@ category: 9. Glossary
 order: 1
 ---
 
-Association Registry
-:   TODO
+Association Register
+:   Register of onboarded Members, and Preferred Business Partners of a particular BDI Association instance.
 
-Authorization Registry
+Authorization Register
 :   Holds authorization policies for one or more data owners on access to data
-    Also known as **AR-DM, Authorization Registry Data Management**
+    Also known as **AR-DM, Authorization Register Data Management**
 
 BDI Association
 :   Legal entity that serves as an operational anchor for both federated trust/authentication
@@ -19,8 +19,8 @@ and local onboarding
 BDI Association Administrator
 :   Functionary responsible for operating the services of a BDI Association
 
-BDI Association Registry
-:   Registry of onboarded members
+BDI Association Register
+:   Register of onboarded members
 
 BDI Authentication Processor
 :   Standard software to make APIs BDI compliant
@@ -29,17 +29,12 @@ BDI Authentication Processor
 Business Partners
 :   Members of other BDI Associations than the root BDI Association
 
-Business Partner Reputation model
-:   Registry within BDI Association, holding
-    Reputation scores of business partners
-    Preferred partners
-
 Client Assertion
-:   TODO
+:   Security mechanism used to authenticate a client. Implemented as a JWT (JSON Web Token) and containing various claims, including about the identity of the client, the identity of the entity being authenticated, and the intended recipient of the assertion.
 
 Data Consumer
-:   Requests access to data and/or Representation Registry and/or Professional Qualification
-Registry of the data owner
+:   Requests access to data and/or Representation Register and/or Professional Qualification
+Register of the data owner
 :   Controls discovery and endpoints
     Requests subscription to data owner’s Event Pub/Sub Service, receives and evaluates events
 
@@ -59,17 +54,17 @@ Data Service Provider
 :   A service provider that acts under the supervision and on behalf of the data owner
 
 Delegation Evidence
-:   TODO. [See also](https://dev.ishare.eu/delegation/delegation-evidence.html)
+:   A mechanism to delegate permissions from one entity to another. Implemented as JWT (JSON Web Token), and contains information about the delegation, including the identity of the delegator, the delegatee, the scope of the delegation, and the validity period. [See also](https://dev.ishare.eu/delegation/delegation-evidence.html)
 
 Delegation Mask
-:   TODO. [See also](https://dev.ishare.eu/delegation/delegation-request.html)
+:   A delegation mask (or request) is a request for delegation. It contains mostly the same information as the delegation evidence, but it has not been approved and signed yet. [See also](https://dev.ishare.eu/delegation/delegation-request.html)
 
 Edge agreements
 :   Standards on interacting with entities and/or persons that have IT systems that are less mature or not BDI-compliant.
     Processes, technology, terms and conditions, liabilities
 
-EORI-ID
-:   TODO
+EORI number
+:   An EORI number (Economic Operators Registration and Identification number) is a unique identifier used in the European Union to track and identify economic operators, such as businesses or individuals, that engage in customs activities. This number is essential for any entity that imports, exports, or engages in customs-related activities within the EU.
 
 Event Pub/Sub Service
 :   Accepts subscription to the data owner’s Event Pub/Sub Service
@@ -89,10 +84,10 @@ Preferred Business Partners
 :   Outsiders
    Those who have agreed to the specific terms and conditions of the local BDI Association, which maintains its own Business Partner Reputation Model
 
-Professional Qualifications Registry
+Professional Qualifications Register
 :   Holds proof of the professional (verifiable) credentials of natural persons in relation to them acting as a representative of a legal entity
 
-Representation Registry
+Representation Register
 :   Holds proof of the mandate of natural persons acting as a representative of a specific legal entity
     Holds proof of the mandate of organizations acting as a representative of a specific legal entity
 


### PR DESCRIPTION
A great deal of the text had already been copied from the glossary page of the gitbook site.
